### PR TITLE
11.connect postgres db

### DIFF
--- a/AppCI/AppCI/settings.py
+++ b/AppCI/AppCI/settings.py
@@ -103,8 +103,12 @@ WSGI_APPLICATION = 'AppCI.wsgi.application'
 
 DATABASES = {
     'default': {
-        'ENGINE': 'django.db.backends.sqlite3',
-        'NAME': BASE_DIR / 'db.sqlite3',
+        'ENGINE': 'django.db.backends.postgresql_psycopg2',
+        'NAME': os.getenv('PG_DB_NAME'),
+        'USER': os.getenv('PG_USER'),
+        'PASSWORD': os.getenv('PG_PASSWORD'),
+        'HOST': os.getenv('PG_HOST'),
+        'PORT': os.getenv('PG_PORT'),
     }
 }
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ asgiref==3.8.1
 Django==5.0.4
 django-cors-headers==4.3.1
 django-vite==3.0.4
+psycopg2==2.9.9
 python-dotenv==1.0.1
 sqlparse==0.5.0
 whitenoise==6.6.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,15 @@
 asgiref==3.8.1
+astroid==3.1.0
+dill==0.3.8
 Django==5.0.4
 django-cors-headers==4.3.1
 django-vite==3.0.4
-psycopg2==2.9.9
+isort==5.13.2
+mccabe==0.7.0
+platformdirs==4.2.1
+psycopg2-binary==2.9.9
+pylint==3.1.0
 python-dotenv==1.0.1
 sqlparse==0.5.0
+tomlkit==0.12.4
 whitenoise==6.6.0


### PR DESCRIPTION
Close #11

Se agrega la configuración para conectarse a una base de datos de postgres.

**Cómo correrlo?**

1) Desde pgAdmin crear una nueva base de datos de nombre AppCI

2) En el .env file (el mismo que tiene la configuración de debug) escribir:

PG_DB_NAME="AppCI"
PG_USER="your_user_name"
PG_PASSWORD="your_postgres_password"
PG_HOST="127.0.0.1"
PG_PORT="5432"
DEBUG=true

3) Instalar los requirements.txt en el env con `pip install -r requirements.txt`

4) en django: 

`python manage.py migrate`

5) En pgAdmin, hacer un refresh en la base de datos creada. Se tienen que ver las tablas que crea django por default

![image](https://github.com/rhoni-team/AppCI/assets/39421618/991ebb2e-71f3-4d70-85e1-e25c65d26880)
