### PR TITLE
feat: security settings

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -14,6 +14,7 @@ env:
   PG_PORT: 5432
   DJANGO_ENV: development
   SECRET_KEY: ${{ secrets.DJANGO_SECRET_KEY }}
+  DJANGO_ALLOWED_HOSTS: localhost
 
 jobs:
   ci:

--- a/AppCI/AppCI/settings.py
+++ b/AppCI/AppCI/settings.py
@@ -52,7 +52,7 @@ DJANGO_VITE_DEV_SERVER_PORT = 3000
 DJANGO_VITE_MANIFEST_PATH = BASE_DIR / 'frontend' / \
     'static' / 'dist' / '.vite' / 'manifest.json'
 
-ALLOWED_HOSTS = ['localhost', '127.0.0.1']
+ALLOWED_HOSTS = os.getenv('DJANGO_ALLOWED_HOSTS').split(' ')
 CORS_ALLOWED_ORIGINS = ["http://localhost:3000", "http://127.0.0.1:8000", ]
 CORS_ALLOW_ALL_ORIGINS = True
 CORS_ALLOW_CREDENTIALS = True
@@ -226,5 +226,5 @@ REST_FRAMEWORK = {
 
 # ssl  ------ UNCOMMENT IN HTTPS
 # SECURE_SSL_REDIRECT = True
-# SECURE_HSTS_SECONDS = 60 # It will be blocked for one minute. Change it if everything is ok.
+# SECURE_HSTS_SECONDS = 10 # It will be blocked for one minute. Change it if everything is ok.
 # SECURE_HSTS_PRELOAD = True

--- a/AppCI/AppCI/settings.py
+++ b/AppCI/AppCI/settings.py
@@ -13,7 +13,6 @@ https://docs.djangoproject.com/en/5.0/ref/settings/
 import os
 import re
 from pathlib import Path
-from xml.etree.ElementPath import find
 import environ
 
 
@@ -79,6 +78,7 @@ LOCAL_APPS = [
 THIRD_APPS = [
     'django_vite',
     'rest_framework',
+    'rest_framework.authtoken',
 ]
 
 INSTALLED_APPS = BASE_APPS + LOCAL_APPS + THIRD_APPS
@@ -198,3 +198,34 @@ def immutable_file_test(path, url):
 WHITENOISE_IMMUTABLE_FILE_TEST = immutable_file_test
 
 DEBUG_PROPAGATE_EXCEPTIONS = False
+
+
+# SECURITY
+
+# cookies
+CSRF_COOKIE_SECURE = True
+SESSION_COOKIE_SECURE = True
+# CSRF_COOKIE_HTTPONLY = True
+
+# subdomains
+# SECURE_HSTS_INCLUDE_SUBDOMAINS = True
+
+# rest framework
+REST_FRAMEWORK = {
+    # 'DEFAULT_THROTTLE_CLASSES': [
+    #     'rest_framework.throttling.UserRateThrottle'
+    # ],
+    # 'DEFAULT_THROTTLE_RATES': {
+    #     'user': '500/day'  # Allow only 500 requests per day for authenticated users
+    # },
+    'DEFAULT_AUTHENTICATION_CLASSES': [
+        'rest_framework.authentication.BasicAuthentication',
+        'rest_framework.authentication.SessionAuthentication',
+        # 'rest_framework.authentication.TokenAuthentication', ------ UNCOMMENT IN HTTPS
+    ],
+}
+
+# ssl  ------ UNCOMMENT IN HTTPS
+# SECURE_SSL_REDIRECT = True
+# SECURE_HSTS_SECONDS = 86400 # one Day
+# SECURE_HSTS_PRELOAD = True

--- a/AppCI/AppCI/settings.py
+++ b/AppCI/AppCI/settings.py
@@ -52,8 +52,7 @@ DJANGO_VITE_DEV_SERVER_PORT = 3000
 DJANGO_VITE_MANIFEST_PATH = BASE_DIR / 'frontend' / \
     'static' / 'dist' / '.vite' / 'manifest.json'
 
-# ALLOWED_HOSTS = ['104.248.77.150', '127.0.0.1']
-ALLOWED_HOSTS = ['*']
+ALLOWED_HOSTS = ['localhost', '127.0.0.1']
 CORS_ALLOWED_ORIGINS = ["http://localhost:3000", "http://127.0.0.1:8000", ]
 CORS_ALLOW_ALL_ORIGINS = True
 CORS_ALLOW_CREDENTIALS = True
@@ -227,5 +226,5 @@ REST_FRAMEWORK = {
 
 # ssl  ------ UNCOMMENT IN HTTPS
 # SECURE_SSL_REDIRECT = True
-# SECURE_HSTS_SECONDS = 86400 # one Day
+# SECURE_HSTS_SECONDS = 60 # It will be blocked for one minute. Change it if everything is ok.
 # SECURE_HSTS_PRELOAD = True

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,7 +35,7 @@ services:
   nginx:
     build: ./nginx
     ports:
-      - 5000:80
+      - 5001:80
     depends_on:
       - django
 volumes:


### PR DESCRIPTION
I added the security parameters for the Django app. Some of them will work over `https`, so they are now commented.

**How to test the app in the server?**

1) install docker and docker compose

2) look up the variable 'ALLOWED_HOSTS' in the AppCI/settings.py file. Add the server ip.

3) run:

`bash run_docker.sh` to build the app. Test it on port 5001.

4) If you need to build the docker again, remember to rebuild the postgres volume with:

`docker compose down`
`sudo rm -r ./.postgres-data/`
